### PR TITLE
Add validation, support two more Webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A app to connect PlanetScale database events to Slack notifications.
 - [Configure webhooks](https://planetscale.com/docs/concepts/webhooks) for your PlanetScale database
 - Set the following environment variables in Vercel:
   - `PLANETSCALE_WEBHOOK_SECRET`: The secret used to verify webhook requests
-  - `SLACK_WEBHOOK_URL`: The URL of your Slack app
+  - `SLACK_BOT_TOKEN`: The URL of your Slack app
   - `SLACK_CHANNEL`: The name of the Slack channel to send messages to
 - To test your app is working you can send a [test webhook](https://planetscale.com/docs/concepts/webhooks#setting-up-a-webhook-in-planetscale) from PlanetScale and a message will be sent to Slack
 - Profit


### PR DESCRIPTION
* This PR adds correct [validation](https://planetscale.com/docs/concepts/webhooks#validating-a-webhook-signature). I actually don't know how it was working before given the way the if on line `34` was written, but this fixes that and does proper signature validation.
* Supports two additional webhook events (branch ready, branch sleeping)