### PR TITLE
Add standalone mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A app to connect PlanetScale database events to Slack notifications.
 
 ![PlanetScale to Slack](https://github.com/samlambert/planetscale-to-slack/assets/1155781/478d465f-0ca4-4312-a6e3-944bae6612ae)
 
-## Setup
+## Vercel Setup
 
 - Create a project on Vercel and deploy this repository
 - Set up a [Slack App](https://api.slack.com/quickstart) with `chat:write` and `chat:write.customize` scopes
@@ -13,6 +13,26 @@ A app to connect PlanetScale database events to Slack notifications.
   - `PLANETSCALE_WEBHOOK_SECRET`: The secret used to verify webhook requests
   - `SLACK_BOT_TOKEN`: The URL of your Slack app
   - `SLACK_CHANNEL`: The name of the Slack channel to send messages to
+- To test your app is working you can send a [test webhook](https://planetscale.com/docs/concepts/webhooks#setting-up-a-webhook-in-planetscale) from PlanetScale and a message will be sent to Slack
+- Profit
+
+## Standalone Setup
+
+- Spin up any cloud VM such as an Amazon EC2 instance or DigitalOcean droplet.
+- Log in and download node, npm, npx, typescript, and any other requirements
+- Choose a domain you own and set up the DNS to point to your instance/droplet (for example, `ps-webhooks.com`)
+- Set up an HTTPS cert [using LetsEncrypt](https://itnext.io/node-express-letsencrypt-generate-a-free-ssl-certificate-and-run-an-https-server-in-5-minutes-a730fbe528ca)
+- Check out this repository
+- From the repository root, create a `.env` file and set up the following variables:
+  - `PLANETSCALE_WEBHOOK_SECRET`: The secret used to verify webhook requests
+  - `SLACK_BOT_TOKEN`: The token for the slack bot of your application
+  - `SLACK_CHANNEL`: The name of the Slack channel to send messages to
+  - `MODE`: Set to `standalone`
+  - `CREDENTIALS_PATH`: The path where the LetsEncrypt variables were saved into (possibly `/etc/letsencrypt/live/yourdomain/`)
+- Start the server with `npx tsx api/index.ts`
+- Set up a [Slack App](https://api.slack.com/quickstart) with `chat:write` and `chat:write.customize` scopes
+- [Configure webhooks](https://planetscale.com/docs/concepts/webhooks) for your PlanetScale database
+  - Set the webhook url to the domain you chose + '/webhook'. For example: `https://ps-webhooks.com/webhook`
 - To test your app is working you can send a [test webhook](https://planetscale.com/docs/concepts/webhooks#setting-up-a-webhook-in-planetscale) from PlanetScale and a message will be sent to Slack
 - Profit
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import https from 'https';
 import express, { Request, Response } from "express";
 import { WebClient } from '@slack/web-api';
 import bodyParser from 'body-parser'
@@ -107,5 +109,17 @@ app.post('/webhook', async (req, res) => {
     res.status(500).send('Error processing webhook');
   }
 });
+
+if (process.env.MODE && process.env.MODE == 'standalone') {
+  const credentialsPath = process.env.CREDENTIALS_PATH;
+  
+  const privateKey = fs.readFileSync(`${credentialsPath}/privkey.pem`, 'utf8');
+  const certificate = fs.readFileSync(`${credentialsPath}/cert.pem`, 'utf8');
+  const ca = fs.readFileSync(`${credentialsPath}/chain.pem`, 'utf8');
+  const credentials = { key: privateKey, cert: certificate, ca: ca };
+  
+  const httpsServer = https.createServer(credentials, app);
+  httpsServer.listen(443, () => console.log('server started') );
+}
 
 export default app;


### PR DESCRIPTION
Adds the `standalone` mode. This allows the code to run as a standalone https server, giving you the ability to deploy it manually to a DigitalOcean Droplet / Amazon EC2 / other VM of your choosing.