### PR TITLE
Add support for branch.schema_recommendation webhook

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -98,6 +98,12 @@ app.post('/webhook', async (req, res) => {
           await sendSlackMessage(`Webhook test recieved from: \`${data.organization}/${data.database}\``);
         break;
 
+        case 'branch.schema_recommendation':
+          const recommendation = data.resource;
+          const recommendationType = recommendation.recommendation_type === 'new_index' ? 'new index' : recommendation.recommendation_type;
+          await sendSlackMessage(`:bulb: <${recommendation.html_url}|Schema recommendation #${recommendation.number}>: ${recommendation.title}\n• Type: ${recommendationType}\n• Table: \`${recommendation.table_name}\`\n• Branch: \`${data.database}/${recommendation.branch.name}\``);
+        break;
+
         default:
             console.log(`Received an unknown event type: ${event.type}`);
         break;

--- a/api/index.ts
+++ b/api/index.ts
@@ -95,7 +95,7 @@ app.post('/webhook', async (req, res) => {
         break;
 
         case 'webhook.test':
-          await sendSlackMessage(`Webhook test recieved from: \`${data.organization}/${data.database}\``);
+          await sendSlackMessage(`Webhook test received from: \`${data.organization}/${data.database}\``);
         break;
 
         case 'branch.schema_recommendation':
@@ -116,6 +116,7 @@ app.post('/webhook', async (req, res) => {
             const htmlUrl = recommendation.html_url || '#';
             
             await sendSlackMessage(`:bulb: <${htmlUrl}|Schema recommendation #${recommendationNumber}>: ${title}\n• Type: ${recommendationType}\n• Table: \`${tableName}\`\n• Branch: \`${data.database}/${branchName}\``);
+            console.log(`Successfully processed schema recommendation webhook for ${data.database}/${branchName}`);
           } catch (error) {
             console.error('Error processing schema recommendation webhook:', error);
             await sendSlackMessage(`:warning: Received schema recommendation webhook but encountered an error processing it.`);


### PR DESCRIPTION
This PR adds support for the new PlanetScale schema recommendation webhook.

## Changes
- Added case handler for 'branch.schema_recommendation' event
- Extracts recommendation data including title, type, table name, and branch info
- Formats message with lightbulb emoji and clickable link to the recommendation
- Follows existing webhook handler patterns

## Example Output
The webhook will send messages like:
💡 Schema recommendation #28: Add index idx_database_branch_collection_on_name on database_branch_collection
• Type: new index
• Table: 
• Branch: 