### PR TITLE
Remove unused intercom_tenant_mapping table

### DIFF
--- a/migrations/001_drop_intercom_tenant_mapping.sql
+++ b/migrations/001_drop_intercom_tenant_mapping.sql
@@ -1,0 +1,5 @@
+-- Migration: Drop unused intercom_tenant_mapping table
+-- PlanetScale Insights detected this table is not being used by the application
+-- This migration safely removes the table to improve schema cleanliness
+
+DROP TABLE `planetscale`.`intercom_tenant_mapping`;

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,20 @@
+# Database Migrations
+
+This directory contains SQL migration files for PlanetScale database schema changes.
+
+## How to Apply Migrations
+
+1. **Using PlanetScale CLI:**
+   ```bash
+   # Apply the migration to a development branch
+   pscale shell <database-name> <branch-name> < 001_drop_intercom_tenant_mapping.sql
+   ```
+
+2. **Using PlanetScale Deploy Requests:**
+   - Create a new branch in PlanetScale
+   - Apply the migration to the branch
+   - Create a deploy request to merge changes to main
+
+## Migration Files
+
+- `001_drop_intercom_tenant_mapping.sql` - Removes unused `intercom_tenant_mapping` table based on PlanetScale Insights recommendation


### PR DESCRIPTION
Remove the `intercom_tenant_mapping` table as it is unused and detected by PlanetScale Insights.

---
<a href="https://cursor.com/background-agent?bcId=bc-03131c56-9c96-4a88-90f1-1822511a0a05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03131c56-9c96-4a88-90f1-1822511a0a05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

